### PR TITLE
Adding const specifiers to input buffer

### DIFF
--- a/arith/fasterfp.c
+++ b/arith/fasterfp.c
@@ -407,7 +407,7 @@ static void fp_random(element_ptr a) {
   mpz_clear(z);
 }
 
-static void fp_from_hash(element_ptr a, void *data, int len) {
+static void fp_from_hash(element_ptr a, const void *data, int len) {
   mpz_t z;
 
   mpz_init(z);
@@ -477,7 +477,7 @@ static int fp_to_bytes(unsigned char *data, element_t a) {
   return n;
 }
 
-static int fp_from_bytes(element_t a, unsigned char *data) {
+static int fp_from_bytes(element_t a, const unsigned char *data) {
   dataptr ad = a->data;
   int n;
   mpz_t z;

--- a/arith/fastfp.c
+++ b/arith/fastfp.c
@@ -266,7 +266,7 @@ static void fp_random(element_ptr a) {
   mpz_clear(z);
 }
 
-static void fp_from_hash(element_ptr a, void *data, int len) {
+static void fp_from_hash(element_ptr a, const void *data, int len) {
   mpz_t z;
 
   mpz_init(z);
@@ -324,7 +324,7 @@ static int fp_to_bytes(unsigned char *data, element_t e) {
   return n;
 }
 
-static int fp_from_bytes(element_t e, unsigned char *data) {
+static int fp_from_bytes(element_t e, const unsigned char *data) {
   int n;
   mpz_t z;
 

--- a/arith/field.c
+++ b/arith/field.c
@@ -640,7 +640,7 @@ void pbc_mpz_out_raw_n(unsigned char *data, int n, mpz_t z) {
 //  buf = H || 0 || H || 1 || H || ...
 //before calling mpz_import
 void pbc_mpz_from_hash(mpz_t z, mpz_t limit,
-                       unsigned char *data, unsigned int len) {
+                       const unsigned char *data, unsigned int len) {
   size_t i = 0, n, count = (mpz_sizeinbase(limit, 2) + 7) / 8;
   unsigned char* buf = pbc_malloc(count * sizeof(unsigned char));
   unsigned char counter = 0;

--- a/arith/fieldquadratic.c
+++ b/arith/fieldquadratic.c
@@ -308,7 +308,7 @@ static void fq_invert(element_ptr n, element_ptr a) {
   element_clear(e1);
 }
 
-static void fq_from_hash(element_ptr n, void *data, int len) {
+static void fq_from_hash(element_ptr n, const void *data, int len) {
   eptr r = n->data;
   int k = len / 2;
   element_from_hash(r->x, data, k);
@@ -328,7 +328,7 @@ static int fq_to_bytes(unsigned char *data, element_t e) {
   return len;
 }
 
-static int fq_from_bytes(element_t e, unsigned char *data) {
+static int fq_from_bytes(element_t e, const unsigned char *data) {
   eptr p = e->data;
   int len;
   len = element_from_bytes(p->x, data);

--- a/arith/montfp.c
+++ b/arith/montfp.c
@@ -438,7 +438,7 @@ static void fp_random(element_ptr a) {
   mpz_clear(z);
 }
 
-static void fp_from_hash(element_ptr a, void *data, int len) {
+static void fp_from_hash(element_ptr a, const void *data, int len) {
   mpz_t z;
 
   mpz_init(z);
@@ -495,7 +495,7 @@ static int fp_to_bytes(unsigned char *data, element_t a) {
   return n;
 }
 
-static int fp_from_bytes(element_t a, unsigned char *data) {
+static int fp_from_bytes(element_t a, const unsigned char *data) {
   fptr p = a->field->data;
   eptr ad = a->data;
   int n;

--- a/arith/multiz.c
+++ b/arith/multiz.c
@@ -363,7 +363,7 @@ static void f_random(element_ptr n) {
   multiz_free(delme);
 }
 
-static void f_from_hash(element_ptr n, void *data, int len) {
+static void f_from_hash(element_ptr n, const void *data, int len) {
   mpz_t z;
   mpz_init(z);
   mpz_import(z, len, -1, 1, -1, 0, data);

--- a/arith/naivefp.c
+++ b/arith/naivefp.c
@@ -175,7 +175,7 @@ static void zp_random(element_ptr n) {
   pbc_mpz_random(n->data, n->field->order);
 }
 
-static void zp_from_hash(element_ptr n, void *data, int len) {
+static void zp_from_hash(element_ptr n, const void *data, int len) {
   pbc_mpz_from_hash(n->data, n->field->order, data, len);
 }
 
@@ -210,7 +210,7 @@ static int zp_to_bytes(unsigned char *data, element_t e) {
   return n;
 }
 
-static int zp_from_bytes(element_t e, unsigned char *data) {
+static int zp_from_bytes(element_t e, const unsigned char *data) {
   mpz_ptr z = e->data;
   int n;
   n = e->field->fixed_length_in_bytes;

--- a/arith/poly.c
+++ b/arith/poly.c
@@ -338,7 +338,7 @@ static void polymod_random(element_ptr e) {
   }
 }
 
-static void polymod_from_hash(element_ptr e, void *data, int len) {
+static void polymod_from_hash(element_ptr e, const void *data, int len) {
   // TODO: Improve this.
   element_t *coeff = e->data;
   int i, n = polymod_field_degree(e->field);
@@ -575,7 +575,7 @@ static int poly_to_bytes(unsigned char *buf, element_t p) {
   return result;
 }
 
-static int poly_from_bytes(element_t p, unsigned char *buf) {
+static int poly_from_bytes(element_t p, const unsigned char *buf) {
   int result = 2;
   int count = buf[0] + buf[1] * 256;
   int i;
@@ -739,7 +739,7 @@ static int polymod_length_in_bytes(element_t f) {
   return res;
 }
 
-static int polymod_from_bytes(element_t f, unsigned char *data) {
+static int polymod_from_bytes(element_t f, const unsigned char *data) {
   mfptr p = f->field->data;
   element_t *coeff = f->data;
   int i, n = p->n;

--- a/arith/ternary_extension_field.c
+++ b/arith/ternary_extension_field.c
@@ -448,7 +448,7 @@ int gf3m_to_bytes(unsigned char *d, element_ptr e) {
     return SIZE(e);
 }
 
-int gf3m_from_bytes(element_ptr e, unsigned char *d) {
+int gf3m_from_bytes(element_ptr e, const unsigned char *d) {
     unsigned long *a = DATA1(e), *b = DATA2(e);
     unsigned i;
     int j;

--- a/arith/z.c
+++ b/arith/z.c
@@ -107,7 +107,7 @@ static void z_random(element_ptr n) {
   mpz_set_ui(n->data, 0);
 }
 
-static void z_from_hash(element_ptr n, void *data, int len) {
+static void z_from_hash(element_ptr n, const void *data, int len) {
   mpz_import(n->data, len, -1, 1, -1, 0, data);
 }
 

--- a/ecc/curve.c
+++ b/ecc/curve.c
@@ -452,7 +452,7 @@ static int curve_sign(element_ptr e) {
   return element_sign(p->y);
 }
 
-static void curve_from_hash(element_t a, void *data, int len) {
+static void curve_from_hash(element_t a, const void *data, int len) {
   element_t t, t1;
   point_ptr p = a->data;
   curve_data_ptr cdp = a->field->data;
@@ -608,7 +608,7 @@ static int curve_to_bytes(unsigned char *data, element_t e) {
   return len;
 }
 
-static int curve_from_bytes(element_t e, unsigned char *data) {
+static int curve_from_bytes(element_t e, const unsigned char *data) {
   point_ptr P = e->data;
   int len;
 
@@ -796,7 +796,7 @@ void curve_from_x(element_ptr e, element_t x) {
 }
 
 // Requires e to be a point on an elliptic curve.
-int element_from_bytes_compressed(element_ptr e, unsigned char *data) {
+int element_from_bytes_compressed(element_ptr e, const unsigned char *data) {
   curve_data_ptr cdp = e->field->data;
   point_ptr P = e->data;
   int len;
@@ -826,7 +826,7 @@ int element_to_bytes_x_only(unsigned char *data, element_ptr e) {
 }
 
 // Requires e to be a point on an elliptic curve.
-int element_from_bytes_x_only(element_ptr e, unsigned char *data) {
+int element_from_bytes_x_only(element_ptr e, const unsigned char *data) {
   curve_data_ptr cdp = e->field->data;
   point_ptr P = e->data;
   int len;

--- a/ecc/pairing.c
+++ b/ecc/pairing.c
@@ -115,7 +115,7 @@ static void gt_out_info(FILE *out, field_ptr f) {
   field_out_info(out, f->data);
 }
 
-static void gt_from_hash(element_ptr e, void *data, int len) {
+static void gt_from_hash(element_ptr e, const void *data, int len) {
   pairing_ptr pairing = e->field->pairing;
   element_from_hash(e->data, data, len);
   pairing->finalpow(e);
@@ -176,7 +176,7 @@ static int mulg_to_bytes(unsigned char *data, element_ptr e) {
   return element_to_bytes(data, e->data);
 }
 
-static int mulg_from_bytes(element_ptr e, unsigned char *data) {
+static int mulg_from_bytes(element_ptr e, const unsigned char *data) {
   return element_from_bytes(e->data, data);
 }
 

--- a/include/pbc_field.h
+++ b/include/pbc_field.h
@@ -76,13 +76,13 @@ struct field_s {
   void (*invert)(element_ptr, element_ptr);
   void (*neg)(element_ptr, element_ptr);
   void (*random)(element_ptr);
-  void (*from_hash)(element_ptr, void *data, int len);
+  void (*from_hash)(element_ptr, const void *data, int len);
   int (*is1)(element_ptr);
   int (*is0)(element_ptr);
   int (*sign)(element_ptr);  // satisfies sign(x) = -sign(-x)
   int (*cmp)(element_ptr, element_ptr);
   int (*to_bytes)(unsigned char *data, element_ptr);
-  int (*from_bytes)(element_ptr, unsigned char *data);
+  int (*from_bytes)(element_ptr, const unsigned char *data);
   int (*length_in_bytes)(element_ptr);
   int fixed_length_in_bytes;  // length of an element in bytes; -1 for variable
   int (*snprint)(char *s, size_t n, element_ptr e);
@@ -254,7 +254,7 @@ static inline pbc_mpsi element_to_si(element_t e) {
 Generate an element 'e' deterministically from
 the 'len' bytes stored in the buffer 'data'.
 */
-static inline void element_from_hash(element_t e, void *data, int len) {
+static inline void element_from_hash(element_t e, const void *data, int len) {
   e->field->from_hash(e, data, len);
 }
 
@@ -479,7 +479,7 @@ static inline int element_to_bytes(unsigned char *data, element_t e) {
 /*@manual etrade
 Reads 'e' from the buffer 'data', and returns the number of bytes read.
 */
-static inline int element_from_bytes(element_t e, unsigned char *data) {
+static inline int element_from_bytes(element_t e, const unsigned char *data) {
   return e->field->from_bytes(e, data);
 }
 
@@ -557,7 +557,7 @@ x-coordinate represented by the buffer 'data'. This is not unique.
 For each 'x'-coordinate, there exist two different points, at least
 for the elliptic curves in PBC. (They are inverses of each other.)
 */
-int element_from_bytes_x_only(element_t e, unsigned char *data);
+int element_from_bytes_x_only(element_t e, const unsigned char *data);
 /*@manual etrade
 Assumes 'e' is a point on an elliptic curve.
 Returns the length in bytes needed to hold the x-coordinate of 'e'.
@@ -576,7 +576,7 @@ Sets element 'e' to the element in compressed form in the buffer of bytes
 'data'.
 Currently only implemented for points on an elliptic curve.
 */
-int element_from_bytes_compressed(element_t e, unsigned char *data);
+int element_from_bytes_compressed(element_t e, const unsigned char *data);
 
 /*@manual etrade
 Returns the number of bytes needed to hold 'e' in compressed form.
@@ -624,7 +624,7 @@ static inline void element_pp_pow_zn(element_t out, element_t power,
 
 void pbc_mpz_out_raw_n(unsigned char *data, int n, mpz_t z);
 void pbc_mpz_from_hash(mpz_t z, mpz_t limit,
-                       unsigned char *data, unsigned int len);
+                       const unsigned char *data, unsigned int len);
 
 /*@manual etrade
 For points, returns the number of coordinates.


### PR DESCRIPTION
This pull request fixes const specifiers of input buffers passed as argument of functions `element_from_bytes()` and `element_from_hash()`.