### PR TITLE
Add C++ wrapper for PBC, and update autotools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ aclocal.m4
 autom4te.cache/
 .dirstamp
 benchmark/benchmark
+benchmark/benchmark_cxx
 benchmark/ellnet
 benchmark/timersa
 config.guess

--- a/Makefile.am
+++ b/Makefile.am
@@ -14,6 +14,9 @@ maintainer-clean-local:
 	debian/libpbc0 debian/libpbc-dev/ debian/*debhelper.log debian/*debhelper debian/*substvars
 
 lib_LTLIBRARIES = libpbc.la 
+if ENABLE_CXX
+lib_LTLIBRARIES += libpbcxx.la
+endif
 
 # this should really be a versioned dir, i.e., $(includedir)/pbc-0.5.0
 library_includedir = $(includedir)/pbc
@@ -32,6 +35,7 @@ include/pbc_i_param.h \
 include/pbc_fp.h \
 include/pbc_ternary_extension_field.h \
 include/pbc.h \
+include/pbcxx.h \
 include/pbc_hilbert.h \
 include/pbc_memory.h \
 include/pbc_mnt.h \
@@ -60,6 +64,16 @@ libpbc_la_SOURCES = arith/field.c arith/z.c \
 	ecc/param.c ecc/a_param.c ecc/d_param.c ecc/e_param.c \
 	ecc/f_param.c ecc/g_param.c
 libpbc_la_LDFLAGS = -lgmp -lm -version-info $(SO_VERSION) $(PBC_LDFLAGS) $(LIBPBC_LDFLAGS)
+
+if ENABLE_CXX
+PBCXX_LTLIBRARIES_OPTION = libpbcxx.la
+endif
+libpbcxx_la_CPPFLAGS = -Iinclude
+libpbcxx_la_SOURCES = cxx/pbcxx.cc
+libpbcxx_la_DEPENDENCIES = libpbc.la
+libpbcxx_la_LIBADD = $(libpbcxx_la_DEPENDENCIES)
+libpbcxx_la_LDFLAGS = $(PBC_LDFLAGS) $(LIBPBCXX_LDFLAGS) \
+  -version-info $(SO_VERSION)
 
 # LDADD is fallback of program_LDADD
 # explicit "-lgmp" fixes error of "undefined reference to GMP symbol"

--- a/Makefile.am
+++ b/Makefile.am
@@ -14,9 +14,6 @@ maintainer-clean-local:
 	debian/libpbc0 debian/libpbc-dev/ debian/*debhelper.log debian/*debhelper debian/*substvars
 
 lib_LTLIBRARIES = libpbc.la 
-if ENABLE_CXX
-lib_LTLIBRARIES += libpbcxx.la
-endif
 
 # this should really be a versioned dir, i.e., $(includedir)/pbc-0.5.0
 library_includedir = $(includedir)/pbc
@@ -65,16 +62,6 @@ libpbc_la_SOURCES = arith/field.c arith/z.c \
 	ecc/f_param.c ecc/g_param.c
 libpbc_la_LDFLAGS = -lgmp -lm -version-info $(SO_VERSION) $(PBC_LDFLAGS) $(LIBPBC_LDFLAGS)
 
-if ENABLE_CXX
-PBCXX_LTLIBRARIES_OPTION = libpbcxx.la
-endif
-libpbcxx_la_CPPFLAGS = -Iinclude
-libpbcxx_la_SOURCES = cxx/pbcxx.cc
-libpbcxx_la_DEPENDENCIES = libpbc.la
-libpbcxx_la_LIBADD = $(libpbcxx_la_DEPENDENCIES)
-libpbcxx_la_LDFLAGS = $(PBC_LDFLAGS) $(LIBPBCXX_LDFLAGS) \
-  -version-info $(SO_VERSION)
-
 # LDADD is fallback of program_LDADD
 # explicit "-lgmp" fixes error of "undefined reference to GMP symbol"
 # explicit "-lm" fixes error of "undefined reference to libm symbol"
@@ -82,6 +69,11 @@ LDADD = libpbc.la -lgmp -lm
 noinst_PROGRAMS = pbc/pbc benchmark/benchmark benchmark/timersa benchmark/ellnet
 noinst_PROGRAMS += guru/fp_test guru/quadratic_test guru/poly_test guru/prodpairing_test
 noinst_PROGRAMS += guru/ternary_extension_field_test guru/eta_T_3_test
+if ENABLE_CXX
+noinst_PROGRAMS += benchmark/benchmark_cxx
+benchmark_benchmark_cxx_CPPFLAGS = -I include
+benchmark_benchmark_cxx_SOURCES = benchmark/benchmark_cxx.cc
+endif
 pbc_pbc_CPPFLAGS = -I include
 pbc_pbc_SOURCES = pbc/parser.tab.c pbc/lex.yy.c pbc/pbc.c pbc/pbc_getline.c misc/darray.c misc/symtab.c
 benchmark_benchmark_CPPFLAGS = -I include

--- a/benchmark/benchmark_cxx.cc
+++ b/benchmark/benchmark_cxx.cc
@@ -1,0 +1,87 @@
+#include <fstream>
+#include <sys/time.h>
+#include <time.h>
+#include "pbcxx.h"
+
+using std::string;
+using std::cout;
+using std::cerr;
+using std::endl;
+using namespace pbc;
+
+double pbc_get_time(void) {
+  static struct timeval last_tv, tv;
+  static int first = 1;
+  static double res = 0;
+
+  if (first) {
+    gettimeofday(&last_tv, NULL);
+    first = 0;
+    return 0;
+  } else {
+    gettimeofday(&tv, NULL);
+    res += tv.tv_sec - last_tv.tv_sec;
+    res += (tv.tv_usec - last_tv.tv_usec) / 1000000.0;
+    last_tv = tv;
+
+    return res;
+  }
+}
+
+// Helper function to read files, mainly for pairing params
+string read_file(const char* filename) {
+  std::ifstream in(filename, std::ios::in | std::ios::binary);
+  if (!in) {
+    cerr << "Could not read file " << filename << ", error: " << errno << endl;
+    return "";
+  }
+
+  // Allocate just the size of the file
+  string result;
+  in.seekg(0, std::ios::end);
+  result.resize(in.tellg());
+  in.seekg(0, std::ios::beg);
+
+  in.read(&result[0], result.size());
+  in.close();
+  return result;
+}
+
+int main(int argc, char **argv) {
+  if (argc <= 1) {
+    cerr << "Usage: " << argv[0] << " [params_file]" << endl;
+    return 1;
+  }
+
+  string pairing_params = read_file(argv[1]);
+  if (pairing_params.length() <= 0) {
+    cerr << "No pairing params" << endl;
+    return 2;
+  }
+
+  Pairing pairing(pairing_params);
+  G1Element x(pairing);
+  G2Element y(pairing);
+  GTElement r(pairing);
+
+  double t0, t1, ttotal;
+
+
+  ttotal = 0.0;
+  const size_t n = 10;
+  for (size_t i = 0; i < n; ++i) {
+    x.set_random();
+    y.set_random();
+
+    t0 = pbc_get_time();
+    r = pairing(x, y);
+    t1 = pbc_get_time();
+    ttotal += t1 - t0;
+
+    x.debug_print("x =");
+    y.debug_print("y =");
+    r.debug_print("r =");
+  }
+  printf("average pairing time = %f\n", ttotal / n);
+  return 0;
+}

--- a/configure.ac
+++ b/configure.ac
@@ -144,6 +144,14 @@ AC_ARG_ENABLE( debug,
                               [with_debug=y],
                               [with_debug=n])
 
+AC_ARG_ENABLE(cxx,
+AS_HELP_STRING([--enable-cxx],[enable C++ support [default=no]]),
+[case $enableval in
+yes|no|detect) ;;
+*) AC_MSG_ERROR([bad value $enableval for --enable-cxx, need yes/no/detect]) ;;
+esac],
+[enable_cxx=no])
+
 CFLAGS="$CFLAGS -Wall -W -Wfloat-equal -Wpointer-arith -Wcast-align -Wstrict-prototypes -Wredundant-decls \
 -Wendif-labels -Wshadow -pipe -ffast-math -U__STRICT_ANSI__ -std=gnu99"
 if test "$with_debug" == "y"; then
@@ -162,6 +170,17 @@ fi
 AC_FUNC_MALLOC
 AC_FUNC_REALLOC
 AC_CHECK_FUNCS([floor gettimeofday memmove memset pow sqrt strchr strdup])
+
+# The C++ compiler, if desired.
+if test $enable_cxx != no; then
+  AC_PROG_CXX
+  AC_PROG_CXXCPP
+  m4_ifndef([AX_CXX_COMPILE_STDCXX_11], [m4_fatal([Missing AX_CXX_COMPILE_STDCXX_11, install autoconf-archive])])
+  AX_CXX_COMPILE_STDCXX_11
+
+fi
+
+AM_CONDITIONAL(ENABLE_CXX, test $enable_cxx = yes)
 
 AC_CONFIG_FILES([Makefile example/Makefile gen/Makefile])
 AC_OUTPUT
@@ -182,6 +201,10 @@ echo "LFLAGS:           $LFLAGS"
 echo "YACC:             $YACC"
 echo "AM_YFLAGS:        $AM_YFLAGS"
 echo "YFLAGS:           $YFLAGS"
+if test $enable_cxx = yes; then
+  echo "      CXX=\"$CXX\""
+  echo "      CXXFLAGS=\"$CXXFLAGS\""
+fi
 echo "-----------------------------------------"
 echo -ne "\n"
 

--- a/configure.ac
+++ b/configure.ac
@@ -69,6 +69,7 @@ AC_SUBST(LIBPBC_LDFLAGS)
 
 # Checks for programs.
 AC_PROG_CC
+AC_PROG_CXX
 AM_PROG_CC_C_O
 AC_PROG_CPP
 AC_PROG_INSTALL
@@ -173,8 +174,6 @@ AC_CHECK_FUNCS([floor gettimeofday memmove memset pow sqrt strchr strdup])
 
 # The C++ compiler, if desired.
 if test $enable_cxx != no; then
-  AC_PROG_CXX
-  AC_PROG_CXXCPP
   m4_ifndef([AX_CXX_COMPILE_STDCXX_11], [m4_fatal([Missing AX_CXX_COMPILE_STDCXX_11, install autoconf-archive])])
   AX_CXX_COMPILE_STDCXX_11
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,14 +1,13 @@
 #-*- Autoconf -*-
 # Process this file with autoconf to produce a configure script.
 
-AC_PREREQ(2.59)
-AC_INIT([pbc], [0.5.14], [blynn@cs.stanford.edu])
+AC_PREREQ([2.71])
+AC_INIT([pbc],[0.5.14],[blynn@cs.stanford.edu])
 AM_INIT_AUTOMAKE
 AC_CONFIG_HEADERS(config.h)
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_SRCDIR([./])
-LT_INIT
-#AC_CANONICAL_HOST
+LT_INIT(win32-dll)
 
 CFLAGS=
 default_fink_path=/sw
@@ -34,7 +33,6 @@ esac
 # Framework for the below was extracted and
 # modeled after the libgmp configure script.
 
-AC_LIBTOOL_WIN32_DLL
 AC_SUBST(LIBPBC_DLL,0)
 
 case $host in
@@ -77,7 +75,7 @@ AC_PROG_INSTALL
 AC_PROG_LN_S
 AC_PROG_MAKE_SET
 
-AC_PROG_LEX
+AC_PROG_LEX(yywrap)
 if test "x$LEX" != xflex; then
   echo "************************"
   echo "flex not found"
@@ -114,14 +112,14 @@ LIBS=
 
 # Checks for header files.
 AC_FUNC_ALLOCA
-AC_HEADER_STDC
 AC_CHECK_HEADERS([stdlib.h string.h sys/time.h])
 
 # Checks for typedefs, structures, and compiler characteristics.
 AC_C_CONST
 AC_C_INLINE
 AC_TYPE_SIZE_T
-AC_HEADER_TIME
+AC_CHECK_HEADERS_ONCE([sys/time.h])
+
 
 dnl setup CFLAGS
 with_enable_optimized="no"

--- a/cxx/pbcxx.cc
+++ b/cxx/pbcxx.cc
@@ -1,0 +1,1 @@
+#include "pbcxx.h"

--- a/cxx/pbcxx.cc
+++ b/cxx/pbcxx.cc
@@ -1,1 +1,0 @@
-#include "pbcxx.h"

--- a/include/pbcxx.h
+++ b/include/pbcxx.h
@@ -1,0 +1,464 @@
+#ifndef PBC_PBCXX_H
+#define PBC_PBCXX_H
+
+#include <iostream>
+#include <string>
+#include <pbc/pbc.h>
+
+// WARNING WARNING WARNING!!!
+// Elements must be destroyed before pairings, otherwise this will SEGFAULT!
+// TODO: find a way to make sure elements are destroyed before pairings.
+
+namespace pbc {
+namespace internal {
+
+using std::string;
+
+// Forward declaration of Pairing class so it can be used to initialize elements
+class Pairing;
+
+// Use an anonymous namespace to prevent internals from leaking
+namespace {
+
+// Function pointer used for initializing elements. Used as a template parameter
+// Should not be used anywhere outside of this file.
+typedef void (*__element_initializer_t)(element_t, pairing_t);
+
+/**
+ * Generic wrapper for PBC elements. First template parameter is a function
+ * pointer for how to initialize an element, serves as differentiation element
+ * types. Second template parameter is the type of the derived class. This is so
+ * that the derived class can be returned from operators, instead of the base
+ * class. Doing so provides a cleaner interface for end users, we just have to
+ * be very careful in this class with how we use it.
+ *
+ * A note on const. PBC basically has no notion of const. If you define a const
+ * element_t, you can't use it anywhere. You'll notice that the element being
+ * wrapped is marked mutable. This is so that even when the instance of the
+ * ElementWrapper is const, we can still call PBC functions. We try here to
+ * never modify the element in a const method, but that's best effort and relies
+ * on PBC being well behaved.
+ *
+ * NB: You probably don't want to instantiate this class. See below for the
+ * classes end users would actually use.
+ */
+template <__element_initializer_t init, class Derived>
+class ElementWrapper {
+  // GElementBase needs to be a friend so that pow_zn and mul_zn can work
+  // access elements across templates.
+  template<__element_initializer_t, class>
+  friend class GElementBase;
+
+  // Allow Pairing to access elements for computing pairings.
+  friend class ::pbc::internal::Pairing;
+
+  // Shortcut for the type of the current template instatiation.
+  typedef ElementWrapper<init, Derived> MyType;
+
+ protected:
+  // Only used in very special cases, inits element same as other but doesn't
+  // copy the value. Used in some operators.
+  ElementWrapper(element_t e) {
+    element_init_same_as(v_, e);
+  }
+
+  // PBC doesn't use const. So we need this to be mutable for cases when we
+  // don't actually modify it, but the compiler doesn't know that.
+  mutable element_t v_;
+
+ public:
+  // Don't allow default construction, need to ensure element is initialized.
+  ElementWrapper() = delete;
+
+  // Initialize an element given a pairing.
+  ElementWrapper(const Pairing& pairing);
+
+  // Initializes and copies an element.
+  ElementWrapper(const MyType& e) {
+    element_init_same_as(v_, e.v_);
+    element_set(v_, e.v_);
+  }
+
+  // Make sure to clean up!
+  ~ElementWrapper() {
+    element_clear(v_);
+  }
+
+  Derived& operator=(const MyType& other) {
+    if (this != &other) {
+      element_set(v_, other.v_);
+    }
+    return *static_cast<Derived*>(this);
+  }
+
+  int compare(const MyType& e) const { return element_cmp(v_, e.v_); }
+
+  bool is0() const { return element_is0(v_); }
+
+  bool is1() const { return element_is1(v_); }
+
+  // Here's an example of returning the derived class and not the base class.
+  // If we didn't have Derived, users would get back a reference to
+  // ElementWrapper and not the class they actually created.
+  Derived& set0() {
+    element_set0(v_);
+    return *static_cast<Derived*>(this);
+  }
+
+  Derived& set1() {
+    element_set1(v_);
+    return *static_cast<Derived*>(this);
+  }
+
+  Derived& set_random() {
+    element_random(v_);
+    return *static_cast<Derived*>(this);
+  }
+
+  Derived& from_hash(const string& data) {
+    element_from_hash(v_, (void*)data.data(), data.size());
+    return *static_cast<Derived*>(this);
+  }
+
+  // Utility function to print a prefix string followed by the element.
+  void debug_print(const char* str) const {
+    element_printf("%s %B\n", str, v_);
+  }
+
+  inline bool operator==(const MyType& other) const {
+    return compare(other) == 0;
+  }
+
+  inline bool operator!=(const MyType& other) const {
+    return compare(other) != 0;
+  }
+
+  Derived& operator+=(const MyType& rhs) {
+    element_add(v_, v_, rhs.v_);
+    return *static_cast<Derived*>(this);
+  }
+
+  friend Derived operator+(const MyType& lhs, const MyType& rhs) {
+    Derived result(lhs.v_);
+    element_add(result.v_, lhs.v_, rhs.v_);
+    return result;
+  }
+
+  Derived& operator-=(const MyType& rhs) {
+    element_sub(v_, v_, rhs.v_);
+    return *static_cast<Derived*>(this);
+  }
+
+  friend Derived operator-(const MyType& lhs, const MyType& rhs) {
+    Derived result(lhs.v_);
+    element_sub(result.v_, lhs.v_, rhs.v_);
+    return result;
+  }
+
+  Derived& operator*=(const MyType& rhs) {
+    element_mul(v_, v_, rhs.v_);
+    return *static_cast<Derived*>(this);
+  }
+
+  friend Derived operator*(const MyType& lhs, const MyType& rhs) {
+    Derived result(lhs.v_);
+    element_mul(result.v_, lhs.v_, rhs.v_);
+    return result;
+  }
+
+  Derived& operator/=(const MyType& rhs) {
+    element_div(v_, v_, rhs.v_);
+    return *static_cast<Derived*>(this);
+  }
+
+  friend Derived operator/(const MyType& lhs, const MyType& rhs) {
+    Derived result(lhs.v_);
+    element_div(result.v_, lhs.v_, rhs.v_);
+    return result;
+  }
+
+  // Double the element and return the new value.
+  Derived twice() {
+    Derived result(v_);
+    element_double(result.v_, v_);
+    return result;
+  }
+
+  // Double the element in place.
+  Derived& twice_inplace() {
+    element_double(v_, v_);
+    return *static_cast<Derived*>(this);
+  }
+
+  // Halve the element in place.
+  // Apparently, halve doesn't actually work in anything other than Zr.
+  // Derived& halve() {
+  //   element_halve(v_, v_);
+  //   return *static_cast<Derived*>(this);
+  // }
+
+  // Square the element and return the new value.
+  Derived square() {
+    Derived result(v_);
+    element_square(result.v_, v_);
+    return result;
+  }
+
+  // Square the element in place.
+  Derived& square_inplace() {
+    element_square(v_, v_);
+    return *static_cast<Derived*>(this);
+  }
+
+  // Negative of the element and return the new value.
+  Derived neg() {
+    Derived result(v_);
+    element_neg(result.v_, v_);
+    return result;
+  }
+
+  // Negative of the element in place.
+  Derived& neg_inplace() {
+    element_neg(v_, v_);
+    return *static_cast<Derived*>(this);
+  }
+
+  // Invert the element and return the new value.
+  Derived invert() {
+    Derived result(v_);
+    element_invert(result.v_, v_);
+    return result;
+  }
+
+  // Invert the element in place.
+  Derived& invert_inplace() {
+    element_invert(v_, v_);
+    return *static_cast<Derived*>(this);
+  }
+
+  // Get a byte representation of the current element.
+  string to_bytes() const {
+    string buf(element_length_in_bytes(v_), 0);
+    element_to_bytes((unsigned char*)&buf[0], v_);
+    return buf;
+  }
+
+  // Extract element data from byte string. Note that PBC method is very unsafe
+  // as it could read past the end of the buffer!
+  Derived& from_bytes(const string& buf) {
+    if (element_length_in_bytes(v_) > buf.size()) {
+      throw std::invalid_argument("Buffer too small for element");
+    }
+    auto n = element_from_bytes(v_, (unsigned char*)&buf[0]);
+    if (n != buf.size()) {
+      // TODO: not sure if this should actually throw. Might be ok?
+      throw std::invalid_argument("wrong number of bytes read");
+    }
+    return *static_cast<Derived*>(this);
+  }
+};
+
+} // namespace
+
+/**
+ * Wrapper for elements in the Zr integer field. Allows for setting from signed
+ * integers and mpz data types. Can also be used a pow_zn exponents.
+ */
+class ZrElement : public ElementWrapper<element_init_Zr, ZrElement> {
+ protected:
+  // Needed so that operators in ElementWrapper can do partial constructions of
+  // this derived class, without defining operators here.
+  friend class ElementWrapper<element_init_Zr, ZrElement>;
+  ZrElement(element_t e) : ElementWrapper(e) {}
+
+ public:
+  // Construct Zr element from definition in pairing.
+  ZrElement(const Pairing& pairing) : ElementWrapper(pairing) {}
+
+  // Copy another Zr element, both parameters and data.
+  ZrElement(const ZrElement& e) : ElementWrapper(e) {}
+
+  // Set Zr element to a signed integer value.
+  ZrElement& set_si(signed long int i) {
+    element_set_si(v_, i);
+    return *this;
+  }
+
+  // Set Zr element to a gmp mpz value.
+  ZrElement& set_mpz(mpz_t z) {
+    element_set_mpz(v_, z);
+    return *this;
+  }
+};
+
+// Keep GElementBase anonymous to prevent leakage
+namespace {
+
+/**
+ * Generic wrapper for G1, G2, GT group elements. Extensions for doing pow_zn
+ * with a Zr element.
+ */
+template <__element_initializer_t init, class Derived>
+class GElementBase : public ElementWrapper<init, Derived> {
+ protected:
+  typedef ElementWrapper<init, Derived> MyWrapper;
+  // Needed so that operators in ElementWrapper can do partial constructions of
+  // this derived class, without defining operators here.
+  friend class ElementWrapper<init, Derived>;
+  GElementBase(element_t e) : MyWrapper(e) {}
+
+ public:
+  // Construct group element from definition in pairing.
+  GElementBase(const Pairing& pairing) : MyWrapper(pairing) {}
+
+  // Copy another group element of the same type, including data.
+  GElementBase(const GElementBase& e) : MyWrapper(e) {}
+
+  // Raise this group element to the power of zn and return result.
+  // Does not modify this instance.
+  Derived pow_zn(const ZrElement& zn) const {
+    Derived result(this->v_);
+    element_pow_zn(result.v_, this->v_, zn.v_);
+    return result;
+  }
+
+  // Raise this group element to the power of zn in place.
+  Derived& pow_zn_inplace(const ZrElement& zn) {
+    element_pow_zn(this->v_, this->v_, zn.v_);
+    return *static_cast<Derived*>(this);
+  }
+
+  // Similar to pow_zn_inplace above, multiply by Zn in place.
+  Derived& operator*=(const ZrElement& rhs) {
+    element_mul_zn(this->v_, this->v_, rhs.v_);
+    return *static_cast<Derived*>(this);
+  }
+
+  // Because we define a new operator*= have to pass through to base class.
+  Derived& operator*=(const GElementBase& rhs) {
+    return this->MyWrapper::operator*=(rhs);
+  }
+
+  // Similar to pow_zn above, multiply by a Zn element without modifying this.
+  friend Derived operator*(const GElementBase& g, const ZrElement& z) {
+    Derived result(g.v_);
+    element_mul_zn(result.v_, g.v_, z.v_);
+    return result;
+  }
+
+  // Same thing just with order swapped.
+  friend Derived operator*(const ZrElement& z, const GElementBase& g) {
+    return g * z;
+  }
+
+  // Again, pass through to base class.
+  friend Derived operator*(const GElementBase& lhs,
+      const GElementBase& rhs) {
+    return static_cast<MyWrapper>(lhs) * static_cast<MyWrapper>(rhs);
+  }
+};
+
+} // namespace
+
+#define __DEFINE_ELEMENT_CLASS(name, init)                   \
+class name : public GElementBase<init, name> {               \
+ protected:                                                  \
+  friend class ElementWrapper<init, name>;                   \
+  friend class GElementBase<init, name>;                     \
+  name(element_t e) : GElementBase(e) {}                     \
+ public:                                                     \
+  name(const Pairing& pairing) : GElementBase(pairing) {}    \
+  name(const name& e) : GElementBase(e) {}                   \
+};
+
+__DEFINE_ELEMENT_CLASS(G1Element, element_init_G1);
+__DEFINE_ELEMENT_CLASS(G2Element, element_init_G2);
+__DEFINE_ELEMENT_CLASS(GTElement, element_init_GT);
+
+#undef __DEFINE_ELEMENT_CLASS
+
+/**
+ * Wrapper for PBC Pairings. This makes it much easier to construct and manage
+ * pairings and elements. Pairing is cleared automatically on destruction.
+ */
+class Pairing {
+  template <__element_initializer_t init, class Derived>
+  friend class ElementWrapper;
+
+ private:
+  // Just like elements, this needs to be mutable as PBC doesn't use const.
+  mutable pairing_t pairing_;
+
+ public:
+
+  // Initialize pairing based on given params.
+  Pairing(const string& params) {
+    pairing_init_set_buf(pairing_, params.c_str(), params.size());
+  }
+
+  ~Pairing() {
+    pairing_clear(pairing_);
+  }
+
+  // Returns true if the pairing is symmetric, false otherwise.
+  bool is_symmetric() const {
+    return pairing_is_symmetric(pairing_);
+  }
+
+  // Apply pairing to g and h and save result in gt. Useful if gt is already
+  // allocated.
+  void apply(GTElement& gt, const G1Element& g, const G2Element& h) const {
+    pairing_apply(gt.v_, g.v_, h.v_, pairing_);
+  }
+
+  // Apply pairing to two elements of the first group. Throws invalid_argument
+  // if the pairing is not symmetric.
+  void apply(GTElement& gt, const G1Element& g, const G1Element& h) const {
+    if (!is_symmetric()) {
+      throw std::invalid_argument("pairing is not symmetric");
+    }
+    pairing_apply(gt.v_, g.v_, h.v_, pairing_);
+  }
+
+  // Apply pairing to two elements of the second group. Throws invalid_argument
+  // if the pairing is not symmetric.
+  void apply(GTElement& gt, const G2Element& g, const G2Element& h) const {
+    if (!is_symmetric()) {
+      throw std::invalid_argument("pairing is not symmetric");
+    }
+    pairing_apply(gt.v_, g.v_, h.v_, pairing_);
+  }
+
+  // Apply pairing to g and h and return the result.
+  GTElement operator()(const G1Element& g, const G2Element& h) const {
+    GTElement gt(*this);
+    apply(gt, g, h);
+    return gt;
+  }
+
+  // Apply pairing to two elements of the first group. Throws invalid_argument
+  // if the pairing is not symmetric.
+  GTElement operator()(const G1Element& g, const G1Element& h) const {
+    GTElement gt(*this);
+    apply(gt, g, h);
+    return gt;
+  }
+
+  // Apply pairing to two elements of the second group. Throws invalid_argument
+  // if the pairing is not symmetric.
+  GTElement operator()(const G2Element& g, const G2Element& h) const {
+    GTElement gt(*this);
+    apply(gt, g, h);
+    return gt;
+  }
+};
+
+template <__element_initializer_t init, class Derived>
+ElementWrapper<init, Derived>::ElementWrapper(const Pairing& pairing) {
+  (*init)(v_, pairing.pairing_);
+}
+
+} // namespace internal
+} // namespace pbc
+
+#endif  // PBC_PBCXX_H

--- a/include/pbcxx.h
+++ b/include/pbcxx.h
@@ -10,7 +10,6 @@
 // TODO: find a way to make sure elements are destroyed before pairings.
 
 namespace pbc {
-namespace internal {
 
 using std::string;
 
@@ -50,7 +49,7 @@ class ElementWrapper {
   friend class GElementBase;
 
   // Allow Pairing to access elements for computing pairings.
-  friend class ::pbc::internal::Pairing;
+  friend class ::pbc::Pairing;
 
   // Shortcut for the type of the current template instatiation.
   typedef ElementWrapper<init, Derived> MyType;
@@ -458,7 +457,6 @@ ElementWrapper<init, Derived>::ElementWrapper(const Pairing& pairing) {
   (*init)(v_, pairing.pairing_);
 }
 
-} // namespace internal
 } // namespace pbc
 
 #endif  // PBC_PBCXX_H

--- a/pbc/pbc.c
+++ b/pbc/pbc.c
@@ -19,6 +19,9 @@
 #include "lex.yy.h"
 #include "parser.tab.h"
 
+// forward declaration to avoid C99 warnings
+int yyparse(void);
+
 int option_easy = 0;
 const char *option_prompt;
 


### PR DESCRIPTION
I've written a C++ wrapper for PBC. It's very lightweight - header only - and just makes it so that you can make C++ objects for Pairings and Elements to do basic operations. No pre-processed (PP) support yet. It should make it very easy for anyone to use PBC in C++ while keeping performance about the same. A few notes:

1. The wrapper is header only and very lightweight. Good part about that is that we don't have to actually compile any C++ other than for testing / benchmarking

2. I've added a benchmark_cxx target to test it out. Should work the same as your existing benchmark, though I couldn't make pbc_get_time link properly for some reason.

3. I have a tonne of unit tests in the googletest framework. Not sure if those are worth investigating? I couldn't see an easy way to add any unit tests.

4. Not all features are currently supported; specifically pp methods aren't there yet. Not sure how important that is.

5. I've added an option to specifically enable C++, but I'm not sure how important that is if it's header only. What do you think? Should we bother with a flag here, or just include it?

6. Right now elements require a Pairing to init, but no attempt is made to ensure that the Pairing is destroyed after any elements. I'm tempted to make it such that Pairings can only be created as shared_ptr, and all elements keep a shared_ptr ref to the pairing to ensure proper deletion. That adds a bit of overhead though. IMO it's a safer choice, what do you think? It would also be easy in that case to enforce that elements must come from the same pairing for any operations.
7. I can't run your release scripts, so you might want to run those yourself before accepting any PRs.