### PR TITLE
fix: z_from_bytes func signature error

### DIFF
--- a/arith/multiz.c
+++ b/arith/multiz.c
@@ -477,7 +477,7 @@ static int z_to_bytes(unsigned char *data, element_t e) {
   return (int)n;
 }
 
-static int z_from_bytes(element_t e, unsigned char *data) {
+static int z_from_bytes(element_t e, const unsigned char *data) {
   unsigned char *ptr;
   size_t i, n;
   mpz_ptr z = e->data;
@@ -495,7 +495,7 @@ static int z_from_bytes(element_t e, unsigned char *data) {
   }
   if (data[4] & 128) {
     neg = 1;
-    data[4] &= 127;
+    ptr[4] &= 127;
   }
   for (i=0; i<n; i++) {
     mpz_set_ui(z1, *ptr);

--- a/arith/z.c
+++ b/arith/z.c
@@ -165,7 +165,7 @@ static int z_to_bytes(unsigned char *data, element_t e) {
   return (int)n;
 }
 
-static int z_from_bytes(element_t e, unsigned char *data) {
+static int z_from_bytes(element_t e, const unsigned char *data) {
   unsigned char *ptr;
   size_t i, n;
   mpz_ptr z = e->data;
@@ -183,7 +183,7 @@ static int z_from_bytes(element_t e, unsigned char *data) {
   }
   if (data[4] & 128) {
     neg = 1;
-    data[4] &= 127;
+    ptr[4] &= 127;
   }
   for (i=0; i<n; i++) {
     mpz_set_ui(z1, *ptr);


### PR DESCRIPTION
When I build pbc lib on my Mac M2 Pro. 

I got this error message:

```
arith/multiz.c:563:17: error: incompatible function pointer types assigning to 'int (*)(element_ptr, const unsigned char *)' (aka 'int (*)(struct element_s *, const unsigned char *)') from 'int (struct element_s *, unsigned char *)' [-Wincompatible-function-pointer-types]
  f->from_bytes = z_from_bytes;
```

It seems that the signature of `z_from_bytes` in `arith/multiz.c` and `arith/z.c` did not match with the function pointer `f->from_bytes`'s signature defined in  `include/pbc_field.h`

Thus, I make the following changes to fix this:

1. add const to z_from_bytes's data variable to match the function signature
2. use temporary pointer `ptr` to handle the neg operation